### PR TITLE
Update 'ajv' dependency to version 8.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15092,7 +15092,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "ajv": "^8.9.0",
+        "ajv": "8.18.0",
         "ajv-formats": "^2.1.1",
         "ajv-keywords": "^5.1.0"
       },
@@ -17500,7 +17500,7 @@
         "@rollup/plugin-node-resolve": "^11.2.1",
         "@rollup/plugin-replace": "^2.4.1",
         "@surma/rollup-plugin-off-main-thread": "^2.2.3",
-        "ajv": "^8.6.0",
+        "ajv": "8.18.0",
         "common-tags": "^1.8.0",
         "fast-json-stable-stringify": "^2.1.0",
         "fs-extra": "^9.0.1",
@@ -17548,7 +17548,7 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "ajv": ">=8"
+        "ajv": "8.18.0"
       }
     },
     "node_modules/workbox-build/node_modules/ajv": {


### PR DESCRIPTION
Updated 'ajv' dependency version to 8.18.0 in package-lock.json.