### PR TITLE
Clean up devDependencies in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,12 +19,6 @@
       },
       "devDependencies": {
         "autoprefixer": "^10.4.24",
-<<<<<<< HEAD
-        "jsonpath": "^1.1.2",
-        "minimatch": "^10.2.1",
-        "nth-check": "^2.1.1",
-=======
->>>>>>> 73c0770 (vercel + dependabot 2)
         "postcss": "^8.4.31",
         "postcss-flexbugs-fixes": "^5.0.2",
         "postcss-normalize": "^13.0.1"


### PR DESCRIPTION
Removed unused devDependencies from package-lock.json.