### PR TITLE
Update @protobufjs/utf8 version to 1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3997,7 +3997,7 @@
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },


### PR DESCRIPTION
Updated version of @protobufjs/utf8 from 1.1.0 to 1.1.1 in package-lock.json.